### PR TITLE
Add advanced sound reactivity pipeline and dashboard integration

### DIFF
--- a/docs/sound-reactivity-redesign-proposal.md
+++ b/docs/sound-reactivity-redesign-proposal.md
@@ -1,0 +1,47 @@
+# AuroraSV2 Sound Reactivity Redesign Proposal
+
+## 1. Current State & Gaps
+- **No dedicated audio pipeline.** The runtime bootstraps MLS-MPM simulation, renderers, and UI from `app.js`, but it never instantiates WebAudio nodes or propagates audio-driven uniforms, so visuals cannot respond to sound.【F:src/app.js†L1-L171】
+- **Configuration lacks audio controls.** `conf.js` exposes particle, simulation, and bloom controls via Tweakpane, yet there are no bindings for audio sensitivity, source selection, or feedback metrics, limiting user interaction with sound-driven behavior.【F:src/conf.js†L1-L117】
+- **Simulation uniforms ignore sonic cues.** The MLS-MPM kernels animate forces, noise, and coloration purely from simulation state, without channels for beat pulses or band-specific energy, preventing rhythm-synchronized motion or palette shifts.【F:src/mls-mpm/mlsMpmSimulator.js†L240-L360】
+- **Visualization feedback is static.** Particle color gradients rely on density and velocity only, missing opportunities for hue shifts, bloom surges, or spatial choreography aligned with musical dynamics.【F:src/mls-mpm/mlsMpmSimulator.js†L334-L379】
+
+## 2. Experience Goals
+- Deliver a **dance-like, kinematic particle performance** that breathes with music—bass swells sculpt volume, mids weave lateral grooves, treble sparks aerial glitter.
+- Provide **intuitive, tactile controls** for selecting inputs (microphone, local file), calibrating sensitivity, sculpting band gains, and tuning groove directionality.
+- Visualize **live audio analytics** (levels, beat envelope, spectral centroid) directly in the dashboard so performers can read the instrument.
+- Support **creative adaptability**: presets for ambient flow vs. percussive burst, toggles for gravity modulation, swirl, and bloom accents.
+- Ensure the system is **resilient and optional**—runs silently when disabled, tolerates missing media devices, and exposes clear lifecycle hooks.
+
+## 3. Target Architecture
+```
+src/
+  audio/
+    soundReactivity.js        # WebAudio engine + feature extraction
+    soundReactivityPanel.js   # Panel wiring (future split once dashboard refactors)
+```
+- **SoundReactivity** orchestrates AudioContext, analyser graph, beat detector, and feature smoothing. It outputs a profile `{ level, beat, bands, flow, color }` consumed by simulation/render modules.
+- **SoundReactivityPanel** (initially co-located within `conf.attachSoundReactivity`) builds advanced Tweakpane controls, file selection buttons, and live monitors. When broader dashboard refactor lands, this migrates into a dedicated module.
+- **Uniform bridge.** `mlsMpmSimulator.setAudioProfile()` maps profile data into new uniforms (`audioLevel`, `audioBands`, `audioBeat`, `audioFlow`, `audioColorPulse`) that animate kernels and shading.
+- **Config integration.** New `conf` fields capture calibration knobs (smoothing, sensitivity, dynamics, band gains, flow/swirl/color weights, beat decay/hold/release) and expose real-time metrics.
+
+## 4. Visualization Strategy
+- **Bass gravity sculpting.** Low-frequency energy injects upward/downward flows and radial breathing, modulating particle confinement and bloom intensity during drops.
+- **Mid groove vectors.** Mid-band levels steer horizontal flow using a phyllotaxis-inspired swirl, introducing kinematic ribbons that orbit the core.
+- **Treble sparkles.** High-band pulses trigger quick color temperature shifts and micro velocity jitter, generating glittering halos synced to hi-hats.
+- **Beat envelopes.** A resilient beat detector triggers shockwave impulses propagating from the simulation centroid, modulating both motion (velocity pushes) and shading (value bursts).
+- **Adaptive palettes.** Audio color pulse influences HSV conversion to amplify chroma and brightness, yielding vibrant splashes during crescendos while staying calm in silence.
+
+## 5. Implementation Roadmap
+1. **Lay foundation** – add `src/audio/soundReactivity.js` with lifecycle (`init`, `enable/disable`, `setSource`, `openFileDialog`, `update`). Implement analyser graph, smoothing, beat detection, and flow vector synthesis. Export profile each frame.
+2. **Panel integration** – extend `conf.js` with audio configuration fields, metrics storage, `attachSoundReactivity()` hook, and Tweakpane folder (source selection, calibration sliders, band gains, flow/color controls, metrics monitors, action buttons).
+3. **Simulation bridge** – introduce audio uniforms and `setAudioProfile()` in `mlsMpmSimulator`. Inject flow/beat impulses into `g2p` velocity integration and feed audio-driven HSV adjustments for color pulses.
+4. **App wiring** – instantiate `SoundReactivity` in `app.js`, call `conf.attachSoundReactivity(soundReactivity)` after initialization, and feed the returned profile into the simulator each frame.
+5. **Polish & presets** – add default parameter presets (e.g., “Chill Flow”, “Percussive Punch”), optional audio output mute, and refine kernels for worker safety (future iteration alongside broader refactor).
+
+## 6. Acceptance Criteria
+- App loads with sound-reactivity disabled by default; enabling microphone/file streams updates dashboard metrics without console errors.
+- Particle motion responds to music: bass drives breathing, beat pulses propagate visible surges, and treble adjusts sparkles.
+- Dashboard monitors reflect real-time band levels and beat envelope within ±1 frame of analyser data.
+- Controls (source switch, calibration sliders, reset button, file picker) react immediately and persist settings across toggles.
+- Feature gracefully deactivates (zeroed uniforms, stopped streams) when disabled or on error.

--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,7 @@ import ParticleRenderer from "./mls-mpm/particleRenderer";
 import BackgroundGeometry from "./backgroundGeometry";
 import { bloom } from 'three/examples/jsm/tsl/display/BloomNode.js';
 import PointRenderer from "./mls-mpm/pointRenderer.js";
+import SoundReactivity from "./audio/soundReactivity";
 
 const loadHdr = async (file) => {
     const texture = await new Promise(resolve => {
@@ -34,6 +35,8 @@ class App {
     controls = null;
 
     lights = null;
+
+    soundReactivity = null;
 
     constructor(renderer) {
         this.renderer = renderer;
@@ -92,6 +95,10 @@ class App {
         const backgroundGeometry = new BackgroundGeometry();
         await backgroundGeometry.init();
         this.scene.add(backgroundGeometry.object);
+
+        this.soundReactivity = new SoundReactivity();
+        await this.soundReactivity.init();
+        conf.attachSoundReactivity(this.soundReactivity);
 
 
         const scenePass = pass(this.scene, this.camera);
@@ -158,6 +165,9 @@ class App {
         this.lights.update(elapsed);
         this.particleRenderer.update();
         this.pointRenderer.update();
+
+        const audioProfile = this.soundReactivity ? this.soundReactivity.update(delta, elapsed) : null;
+        this.mlsMpmSim.setAudioProfile(audioProfile);
 
         await this.mlsMpmSim.update(delta,elapsed);
 

--- a/src/audio/soundReactivity.js
+++ b/src/audio/soundReactivity.js
@@ -1,0 +1,344 @@
+import * as THREE from "three/webgpu";
+import { conf } from "../conf";
+
+const ZERO_METRICS = { level: 0, beat: 0, bass: 0, mid: 0, treble: 0 };
+
+const clamp01 = (value) => THREE.MathUtils.clamp(value, 0, 1);
+
+class SoundReactivity {
+    audioContext = null;
+    analyser = null;
+    gainNode = null;
+    sourceNode = null;
+    bufferSource = null;
+    mediaStream = null;
+    fileInput = null;
+    fileBuffer = null;
+
+    frequencyData = null;
+    timeDomainData = null;
+
+    enabled = false;
+    sourceType = "microphone";
+
+    level = 0;
+    beatEnvelope = 0;
+    beatThreshold = 0.35;
+    beatHoldTimer = 0;
+    swirlPhase = 0;
+
+    profile = {
+        level: 0,
+        beat: 0,
+        bands: { low: 0, mid: 0, high: 0 },
+        flow: new THREE.Vector3(),
+        colorPulse: 0,
+    };
+
+    constructor() {
+    }
+
+    async init() {
+        if (this.fileInput) { return; }
+        const input = document.createElement("input");
+        input.type = "file";
+        input.accept = "audio/*";
+        input.style.display = "none";
+        input.addEventListener("change", async (event) => {
+            const files = event.target.files;
+            if (files && files[0]) {
+                await this.loadFile(files[0]);
+            }
+            event.target.value = "";
+        });
+        document.body.appendChild(input);
+        this.fileInput = input;
+    }
+
+    async ensureContext() {
+        if (!this.audioContext) {
+            this.audioContext = new (window.AudioContext || window.webkitAudioContext)();
+        }
+        if (this.audioContext.state === "suspended") {
+            await this.audioContext.resume();
+        }
+    }
+
+    async enable() {
+        if (this.enabled) { return; }
+        this.enabled = true;
+        try {
+            await this.ensureContext();
+            await this.connectSourceGraph();
+        } catch (error) {
+            console.error("[SoundReactivity] Failed to enable", error);
+            this.disable();
+            conf.audioEnabled = false;
+            if (conf.gui) {
+                conf.gui.refresh();
+            }
+        }
+    }
+
+    disable() {
+        if (!this.enabled) { return; }
+        this.enabled = false;
+        this.disconnectSource();
+        this.clearProfile();
+        if (conf.audioEnabled) {
+            conf.audioEnabled = false;
+            if (conf.gui) { conf.gui.refresh(); }
+        }
+    }
+
+    async connectSourceGraph() {
+        if (this.sourceType === "file") {
+            if (!this.fileBuffer) {
+                this.openFileDialog();
+                return;
+            }
+            this.startFilePlayback();
+        } else {
+            await this.connectMicrophone();
+        }
+    }
+
+    async connectMicrophone() {
+        if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+            throw new Error("Microphone input is not supported in this browser.");
+        }
+        this.disconnectSource();
+        this.mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true, video: false });
+        const micSource = this.audioContext.createMediaStreamSource(this.mediaStream);
+        this.buildGraph(micSource, { monitor: false });
+    }
+
+    startFilePlayback() {
+        if (!this.fileBuffer) { return; }
+        this.disconnectSource();
+        const bufferSource = this.audioContext.createBufferSource();
+        bufferSource.buffer = this.fileBuffer;
+        bufferSource.loop = true;
+        this.buildGraph(bufferSource, { monitor: true });
+        bufferSource.start();
+        this.bufferSource = bufferSource;
+    }
+
+    buildGraph(sourceNode, { monitor }) {
+        this.sourceNode = sourceNode;
+        this.gainNode = this.audioContext.createGain();
+        this.analyser = this.audioContext.createAnalyser();
+        this.analyser.fftSize = 2048;
+        this.analyser.smoothingTimeConstant = THREE.MathUtils.clamp(conf.audioSmoothing, 0, 0.99);
+
+        sourceNode.connect(this.gainNode);
+        this.gainNode.connect(this.analyser);
+        if (monitor) {
+            this.gainNode.connect(this.audioContext.destination);
+        }
+
+        this.frequencyData = new Uint8Array(this.analyser.frequencyBinCount);
+        this.timeDomainData = new Uint8Array(this.analyser.fftSize);
+    }
+
+    disconnectSource() {
+        if (this.bufferSource) {
+            try { this.bufferSource.stop(); } catch (e) { /* ignore */ }
+            this.bufferSource.disconnect();
+            this.bufferSource = null;
+        }
+        if (this.sourceNode) {
+            this.sourceNode.disconnect();
+            this.sourceNode = null;
+        }
+        if (this.gainNode) {
+            this.gainNode.disconnect();
+            this.gainNode = null;
+        }
+        if (this.analyser) {
+            this.analyser.disconnect();
+            this.analyser = null;
+        }
+        if (this.mediaStream) {
+            this.mediaStream.getTracks().forEach(track => track.stop());
+            this.mediaStream = null;
+        }
+        this.frequencyData = null;
+        this.timeDomainData = null;
+    }
+
+    async loadFile(file) {
+        try {
+            await this.ensureContext();
+            const arrayBuffer = await file.arrayBuffer();
+            const audioBuffer = await this.audioContext.decodeAudioData(arrayBuffer);
+            this.fileBuffer = audioBuffer;
+            this.sourceType = "file";
+            conf.audioSource = "file";
+            if (this.enabled) {
+                this.startFilePlayback();
+            }
+        } catch (error) {
+            console.error("[SoundReactivity] Failed to load audio file", error);
+        }
+    }
+
+    openFileDialog() {
+        if (!this.fileInput) { return; }
+        this.fileInput.click();
+    }
+
+    setSource(source) {
+        if (source !== "file" && source !== "microphone") { return; }
+        this.sourceType = source;
+        conf.audioSource = source;
+        if (this.enabled) {
+            this.connectSourceGraph();
+        }
+    }
+
+    resetCalibration() {
+        this.level = 0;
+        this.beatEnvelope = 0;
+        this.beatThreshold = 0.35;
+        this.beatHoldTimer = 0;
+        this.swirlPhase = 0;
+    }
+
+    clearProfile() {
+        this.level = 0;
+        this.beatEnvelope = 0;
+        this.beatThreshold = 0.35;
+        this.beatHoldTimer = 0;
+        this.profile.level = 0;
+        this.profile.beat = 0;
+        this.profile.bands.low = 0;
+        this.profile.bands.mid = 0;
+        this.profile.bands.high = 0;
+        this.profile.flow.set(0, 0, 0);
+        this.profile.colorPulse = 0;
+        conf.updateAudioMetrics(ZERO_METRICS);
+    }
+
+    update(delta, elapsed) {
+        if (!this.enabled || !this.analyser || !this.frequencyData || !this.timeDomainData) {
+            this.clearProfile();
+            return null;
+        }
+
+        this.analyser.smoothingTimeConstant = THREE.MathUtils.clamp(conf.audioSmoothing, 0, 0.99);
+        this.analyser.getByteFrequencyData(this.frequencyData);
+        this.analyser.getByteTimeDomainData(this.timeDomainData);
+
+        const bands = this.computeBandEnergies();
+        const waveformEnergy = this.computeWaveformEnergy();
+
+        const sensitivity = conf.audioSensitivity;
+        const dynamics = conf.audioDynamics;
+        const smoothing = THREE.MathUtils.clamp(conf.audioSmoothing, 0, 0.95);
+
+        const baseLevel = (bands.low + bands.mid + bands.high + waveformEnergy) * 0.25;
+        const calibratedLevel = Math.pow(Math.max(0, baseLevel * sensitivity), THREE.MathUtils.clamp(dynamics, 0.1, 3.0));
+        this.level = THREE.MathUtils.lerp(this.level, calibratedLevel, 1 - smoothing);
+
+        this.updateBeat(delta);
+
+        const lowEnergy = Math.pow(Math.max(0, bands.low * conf.audioBassGain), THREE.MathUtils.clamp(dynamics, 0.1, 3.0));
+        const midEnergy = Math.pow(Math.max(0, bands.mid * conf.audioMidGain), THREE.MathUtils.clamp(dynamics, 0.1, 3.0));
+        const highEnergy = Math.pow(Math.max(0, bands.high * conf.audioTrebleGain), THREE.MathUtils.clamp(dynamics, 0.1, 3.0));
+
+        const displacement = conf.audioDisplacement;
+        const flowWeight = conf.audioFlow;
+        const swirlWeight = conf.audioSwirl;
+
+        this.swirlPhase += delta * (0.6 + highEnergy * 5 * swirlWeight + this.beatEnvelope * 2.5);
+        const flow = this.profile.flow;
+        flow.set(
+            Math.sin(this.swirlPhase) * midEnergy * displacement,
+            (lowEnergy * 2 - 0.6) * displacement,
+            Math.cos(this.swirlPhase) * (highEnergy + midEnergy * 0.5) * displacement
+        );
+        flow.multiplyScalar(flowWeight);
+
+        const colorPulse = THREE.MathUtils.clamp(highEnergy * conf.audioColorBoost + this.beatEnvelope * 0.5, 0, 2);
+
+        this.profile.level = clamp01(this.level);
+        this.profile.beat = clamp01(this.beatEnvelope);
+        this.profile.bands.low = THREE.MathUtils.clamp(lowEnergy, 0, 2);
+        this.profile.bands.mid = THREE.MathUtils.clamp(midEnergy, 0, 2);
+        this.profile.bands.high = THREE.MathUtils.clamp(highEnergy, 0, 2);
+        this.profile.colorPulse = colorPulse;
+
+        conf.updateAudioMetrics({
+            level: this.profile.level,
+            beat: this.profile.beat,
+            bass: this.profile.bands.low,
+            mid: this.profile.bands.mid,
+            treble: this.profile.bands.high,
+        });
+
+        return this.profile;
+    }
+
+    updateBeat(delta) {
+        const beatHold = Math.max(0.05, conf.audioBeatHold);
+        const beatDecay = THREE.MathUtils.clamp(conf.audioBeatDecay, 0.5, 0.999);
+        const beatRelease = Math.max(0.5, conf.audioBeatRelease);
+
+        this.beatHoldTimer += delta;
+        const thresholdTarget = this.level * 0.85;
+        this.beatThreshold = THREE.MathUtils.lerp(this.beatThreshold, thresholdTarget, 1 - beatDecay);
+
+        if (this.level > this.beatThreshold && this.beatHoldTimer > beatHold) {
+            this.beatEnvelope = 1;
+            this.beatHoldTimer = 0;
+            this.beatThreshold = this.level * 1.05;
+        } else {
+            const releaseRate = delta * beatRelease;
+            this.beatEnvelope = Math.max(0, this.beatEnvelope - releaseRate);
+        }
+    }
+
+    computeBandEnergies() {
+        const freqData = this.frequencyData;
+        const length = freqData.length;
+        if (!length) { return { low: 0, mid: 0, high: 0 }; }
+
+        const lowEnd = Math.max(1, Math.floor(length * 0.12));
+        const midEnd = Math.max(lowEnd + 1, Math.floor(length * 0.5));
+
+        let lowSum = 0;
+        let midSum = 0;
+        let highSum = 0;
+
+        for (let i = 0; i < length; i++) {
+            const value = freqData[i] / 255;
+            if (i < lowEnd) {
+                lowSum += value;
+            } else if (i < midEnd) {
+                midSum += value;
+            } else {
+                highSum += value;
+            }
+        }
+
+        const low = lowSum / lowEnd;
+        const mid = midSum / Math.max(1, midEnd - lowEnd);
+        const high = highSum / Math.max(1, length - midEnd);
+
+        return { low: clamp01(low), mid: clamp01(mid), high: clamp01(high) };
+    }
+
+    computeWaveformEnergy() {
+        const data = this.timeDomainData;
+        if (!data || !data.length) { return 0; }
+        let sum = 0;
+        for (let i = 0; i < data.length; i++) {
+            const centered = (data[i] - 128) / 128;
+            sum += centered * centered;
+        }
+        return clamp01(Math.sqrt(sum / data.length));
+    }
+}
+
+export default SoundReactivity;


### PR DESCRIPTION
## Summary
- document the sound reactivity redesign goals and architecture
- add a WebAudio-based sound reactivity engine with beat-driven feature extraction
- extend the dashboard and simulator with audio uniforms, controls, and metrics to drive visuals

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7dd75233c83278e4a9f5f188c28df