### PR TITLE
Implement configurable depth-of-field post FX pipeline

### DIFF
--- a/docs/post_fx_pipeline.json
+++ b/docs/post_fx_pipeline.json
@@ -1,0 +1,222 @@
+{
+  "pipeline": [
+    {
+      "step_number": 1,
+      "operation": "Preprocess",
+      "node": "LuminancePrefilter",
+      "parameters": {
+        "exposureCompensation": 0.0,
+        "maxLuma": 32.0,
+        "toneMap": "aces"
+      },
+      "validation": "Histogram remains unclipped; dynamic range preserved for downstream bloom."
+    },
+    {
+      "step_number": 2,
+      "operation": "Blur",
+      "node": "HashBlur",
+      "parameters": {
+        "radius": 18.0,
+        "iterations": 3,
+        "directionalMode": "pyramid",
+        "tileSize": 16
+      },
+      "validation": "Edge detail is sufficiently softened while cost stays under 1.5ms at 1440p."
+    },
+    {
+      "step_number": 3,
+      "operation": "Mask",
+      "node": "RadialMaskNode",
+      "parameters": {
+        "center": [0.5, 0.5],
+        "innerRadius": 0.18,
+        "outerRadius": 0.62,
+        "falloff": "smoothstep"
+      },
+      "validation": "Blend map shows crisp center with gradual falloff; no banding in 10-bit buffer."
+    },
+    {
+      "step_number": 4,
+      "operation": "Composite",
+      "node": "MaskedMixNode",
+      "parameters": {
+        "foreground": "sceneColor",
+        "background": "blurOutput",
+        "mask": "radialMask"
+      },
+      "validation": "Focus plane remains tack sharp; periphery fully transitions to blur without halos."
+    },
+    {
+      "step_number": 5,
+      "operation": "Chromatic Aberration",
+      "node": "ChromaticAberrationNode",
+      "parameters": {
+        "mode": "RGBShift",
+        "maxOffset": [1.6, -1.4],
+        "scaleByMask": true,
+        "dispersionCurve": "quadratic"
+      },
+      "validation": "CA ramps up smoothly toward edges; center remains neutral with <0.2px drift."
+    },
+    {
+      "step_number": 6,
+      "operation": "Bloom",
+      "node": "BloomNode",
+      "parameters": {
+        "threshold": 0.82,
+        "intensity": 0.9,
+        "knee": 0.6,
+        "iterations": 5,
+        "bicubicUpsample": true
+      },
+      "validation": "Highlight roll-off is clean; bloom halo respects focus mask and avoids clipping."
+    },
+    {
+      "step_number": 7,
+      "operation": "Lens Streaks",
+      "node": "AnamorphicNode",
+      "parameters": {
+        "enabled": true,
+        "orientation": 0.0,
+        "stretch": 2.4,
+        "threshold": 0.88,
+        "intensity": 0.35
+      },
+      "validation": "Horizontal streaks appear only on bright sources; no cross-talk with CA fringes."
+    },
+    {
+      "step_number": 8,
+      "operation": "Temporal Smoothing",
+      "node": "TRAANode",
+      "parameters": {
+        "feedback": 0.08,
+        "clamp": 0.12,
+        "motionVectors": "hdrMotionTex"
+      },
+      "validation": "Temporal shimmer is reduced while preserving motion detail; ghosting <5%."
+    }
+  ],
+  "control_panels": {
+    "Focus Controls": {
+      "Center X": {
+        "type": "slider",
+        "range": [0.0, 1.0],
+        "default": 0.5,
+        "binds": "RadialMaskNode.center.x"
+      },
+      "Center Y": {
+        "type": "slider",
+        "range": [0.0, 1.0],
+        "default": 0.5,
+        "binds": "RadialMaskNode.center.y"
+      },
+      "Focus Radius": {
+        "type": "range",
+        "range": [0.05, 0.6],
+        "default": 0.18,
+        "binds": "RadialMaskNode.innerRadius"
+      },
+      "Focus Falloff": {
+        "type": "range",
+        "range": [0.1, 1.0],
+        "default": 0.44,
+        "binds": "RadialMaskNode.outerRadius"
+      }
+    },
+    "Blur Tuning": {
+      "Blur Radius": {
+        "type": "range",
+        "range": [6, 32],
+        "default": 18,
+        "binds": "HashBlur.radius"
+      },
+      "Blur Quality": {
+        "type": "dropdown",
+        "options": ["fast", "balanced", "cinematic"],
+        "default": "balanced",
+        "binds": {
+          "fast": {"iterations": 2, "tileSize": 24},
+          "balanced": {"iterations": 3, "tileSize": 16},
+          "cinematic": {"iterations": 4, "tileSize": 12}
+        }
+      }
+    },
+    "Chromatic Aberration": {
+      "Intensity": {
+        "type": "range",
+        "range": [0.0, 2.5],
+        "default": 1.0,
+        "binds": "ChromaticAberrationNode.maxOffsetScale"
+      },
+      "Curve Bias": {
+        "type": "range",
+        "range": [0.0, 2.0],
+        "default": 1.0,
+        "binds": "ChromaticAberrationNode.dispersionCurve"
+      }
+    },
+    "Bloom": {
+      "Threshold": {
+        "type": "range",
+        "range": [0.5, 1.2],
+        "default": 0.82,
+        "binds": "BloomNode.threshold"
+      },
+      "Intensity": {
+        "type": "range",
+        "range": [0.2, 2.0],
+        "default": 0.9,
+        "binds": "BloomNode.intensity"
+      },
+      "Soft Knee": {
+        "type": "range",
+        "range": [0.1, 1.0],
+        "default": 0.6,
+        "binds": "BloomNode.knee"
+      }
+    },
+    "Lens FX": {
+      "Streak Toggle": {
+        "type": "switch",
+        "default": true,
+        "binds": "AnamorphicNode.enabled"
+      },
+      "Streak Intensity": {
+        "type": "range",
+        "range": [0.0, 1.0],
+        "default": 0.35,
+        "binds": "AnamorphicNode.intensity"
+      }
+    },
+    "Temporal": {
+      "Stability": {
+        "type": "range",
+        "range": [0.0, 0.2],
+        "default": 0.08,
+        "binds": "TRAANode.feedback"
+      },
+      "Clamp": {
+        "type": "range",
+        "range": [0.05, 0.3],
+        "default": 0.12,
+        "binds": "TRAANode.clamp"
+      }
+    }
+  },
+  "performance_considerations": {
+    "renderScale": "Allow internal render at 0.85x when GPU time exceeds 8ms, upscale with FSR2 for parity.",
+    "asynchronousCompute": "Schedule HashBlur and Bloom downsample passes on async compute queue to overlap with lighting resolve.",
+    "sharedBuffers": "Reuse mip-chain buffers between blur and bloom to minimize VRAM footprint.",
+    "physicsIntegration": "Expose camera depth-of-field focal plane from physics-based focus solver; update radial mask center based on tracked object pose."
+  },
+  "error_handling": {
+    "fallbacks": "If ChromaticAberrationNode unsupported, degrade to single-pass RGB split shader.",
+    "clamping": "Clamp user-driven offsets to avoid sampling outside render target.",
+    "temporalReset": "Reset TRAA history on camera cuts or velocity buffer loss.",
+    "validation": "Run GPU capability check before enabling async compute path; log warnings on fallback."
+  },
+  "input_output_spec": {
+    "input_format": "Linear or HDR10 RGBA scene color texture at full resolution with motion vectors, depth, and luminance histogram buffers.",
+    "output_format": "Tone-mapped RGBA texture with selective focus blur, edge chromatic aberration, bloom, optional lens streaks, and temporal smoothing applied."
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -58,8 +58,20 @@ export interface PostFxConfig {
   bloomThreshold: number;
   bloomStrength: number;
   bloomRadius: number;
-  chromaticAberration: number;
-  vignetteStrength: number;
+  focusCenter: [number, number];
+  focusInnerRadius: number;
+  focusOuterRadius: number;
+  blurStrength: number;
+  blurIterations: number;
+  chromaticAberrationStrength: number;
+  chromaticAberrationScale: number;
+  lensStreaks: boolean;
+  lensStreakIntensity: number;
+  lensStreakThreshold: number;
+  lensStreakStretch: number;
+  temporalEnabled: boolean;
+  temporalFeedback: number;
+  temporalBlend: number;
 }
 
 export interface AudioConfig {
@@ -155,11 +167,23 @@ export const defaultConfig: AppConfig = {
   },
   postfx: {
     bloom: true,
-    bloomThreshold: 0.001,
-    bloomStrength: 0.94,
-    bloomRadius: 0.8,
-    chromaticAberration: 0.0025,
-    vignetteStrength: 0.4,
+    bloomThreshold: 0.82,
+    bloomStrength: 0.9,
+    bloomRadius: 0.6,
+    focusCenter: [0.5, 0.5],
+    focusInnerRadius: 0.2,
+    focusOuterRadius: 0.62,
+    blurStrength: 0.045,
+    blurIterations: 36,
+    chromaticAberrationStrength: 0.9,
+    chromaticAberrationScale: 1.1,
+    lensStreaks: true,
+    lensStreakIntensity: 0.28,
+    lensStreakThreshold: 0.88,
+    lensStreakStretch: 2.4,
+    temporalEnabled: true,
+    temporalFeedback: 0.85,
+    temporalBlend: 0.5,
   },
   audio: {
     enabled: false,

--- a/src/context.ts
+++ b/src/context.ts
@@ -150,6 +150,8 @@ export interface PostFxService {
   pipeline: THREE.PostProcessing;
   bloomPass: unknown;
   scenePass: unknown;
+  lensPass?: unknown;
+  temporalNode?: unknown;
 }
 
 export interface DashboardService {

--- a/src/io/dashboard.ts
+++ b/src/io/dashboard.ts
@@ -1,10 +1,17 @@
 import type { ModuleInstance, TickInfo, AppContext, DashboardService } from "../context";
 import type { AppConfig } from "../config";
 
+interface SliderControl {
+  input: HTMLInputElement;
+  setValue: (value: number) => void;
+}
+
 interface DashboardState {
   container: HTMLDivElement | null;
   audioToggle: HTMLInputElement | null;
   bloomToggle: HTMLInputElement | null;
+  lensToggle: HTMLInputElement | null;
+  temporalToggle: HTMLInputElement | null;
   renderSelect: HTMLSelectElement | null;
   fpsLabel: HTMLSpanElement | null;
   frameLabel: HTMLSpanElement | null;
@@ -12,6 +19,16 @@ interface DashboardState {
   beatLabel: HTMLSpanElement | null;
   unsubscribeConfig: (() => void) | null;
   fpsAvg: number;
+  focusX: SliderControl | null;
+  focusY: SliderControl | null;
+  focusRadius: SliderControl | null;
+  focusFeather: SliderControl | null;
+  blurStrength: SliderControl | null;
+  chromaStrength: SliderControl | null;
+  bloomStrength: SliderControl | null;
+  lensIntensity: SliderControl | null;
+  temporalBlend: SliderControl | null;
+  temporalFeedback: SliderControl | null;
 }
 
 const createContainer = () => {
@@ -71,6 +88,63 @@ const createToggle = (label: string) => {
   return { wrapper, input };
 };
 
+const createSlider = (
+  label: string,
+  {
+    min,
+    max,
+    step,
+    initial,
+    format,
+  }: {
+    min: number;
+    max: number;
+    step: number;
+    initial?: number;
+    format?: (value: number) => string;
+  }
+): { wrapper: HTMLDivElement; input: HTMLInputElement; setValue: (value: number) => void } => {
+  const wrapper = document.createElement("div");
+  wrapper.style.display = "grid";
+  wrapper.style.rowGap = "4px";
+
+  const header = document.createElement("div");
+  header.style.display = "flex";
+  header.style.alignItems = "center";
+  header.style.justifyContent = "space-between";
+
+  const text = document.createElement("span");
+  text.textContent = label;
+  text.style.fontWeight = "500";
+
+  const valueLabel = document.createElement("span");
+  valueLabel.style.opacity = "0.7";
+  valueLabel.style.fontVariantNumeric = "tabular-nums";
+
+  header.appendChild(text);
+  header.appendChild(valueLabel);
+
+  const input = document.createElement("input");
+  input.type = "range";
+  input.min = min.toString();
+  input.max = max.toString();
+  input.step = step.toString();
+  input.value = (initial ?? min).toString();
+
+  const setValue = (value: number) => {
+    input.value = value.toString();
+    const formatted = format ? format(value) : value.toFixed(2);
+    valueLabel.textContent = formatted;
+  };
+
+  setValue(initial ?? min);
+
+  wrapper.appendChild(header);
+  wrapper.appendChild(input);
+
+  return { wrapper, input, setValue };
+};
+
 const createSelect = (label: string, options: Array<{ value: string; text: string }>) => {
   const wrapper = document.createElement("label");
   wrapper.style.display = "grid";
@@ -127,8 +201,33 @@ const applyConfigToControls = (state: DashboardState, config: AppConfig) => {
   if (state.bloomToggle) {
     state.bloomToggle.checked = config.postfx.bloom;
   }
+  if (state.lensToggle) {
+    state.lensToggle.checked = config.postfx.lensStreaks;
+  }
+  if (state.temporalToggle) {
+    state.temporalToggle.checked = config.postfx.temporalEnabled;
+  }
   if (state.renderSelect) {
     state.renderSelect.value = config.render.mode;
+  }
+  state.focusX?.setValue(config.postfx.focusCenter[0]);
+  state.focusY?.setValue(config.postfx.focusCenter[1]);
+  state.focusRadius?.setValue(config.postfx.focusInnerRadius);
+  state.focusFeather?.setValue(config.postfx.focusOuterRadius);
+  state.blurStrength?.setValue(config.postfx.blurStrength);
+  state.chromaStrength?.setValue(config.postfx.chromaticAberrationStrength);
+  state.bloomStrength?.setValue(config.postfx.bloomStrength);
+  state.lensIntensity?.setValue(config.postfx.lensStreakIntensity);
+  state.temporalBlend?.setValue(config.postfx.temporalBlend);
+  state.temporalFeedback?.setValue(config.postfx.temporalFeedback);
+  if (state.lensIntensity) {
+    state.lensIntensity.input.disabled = !config.postfx.lensStreaks;
+  }
+  if (state.temporalBlend) {
+    state.temporalBlend.input.disabled = !config.postfx.temporalEnabled;
+  }
+  if (state.temporalFeedback) {
+    state.temporalFeedback.input.disabled = !config.postfx.temporalEnabled;
   }
 };
 
@@ -138,6 +237,8 @@ export const createDashboardModule = (): ModuleInstance => {
     container: null,
     audioToggle: null,
     bloomToggle: null,
+    lensToggle: null,
+    temporalToggle: null,
     renderSelect: null,
     fpsLabel: null,
     frameLabel: null,
@@ -145,6 +246,16 @@ export const createDashboardModule = (): ModuleInstance => {
     beatLabel: null,
     unsubscribeConfig: null,
     fpsAvg: 0,
+    focusX: null,
+    focusY: null,
+    focusRadius: null,
+    focusFeather: null,
+    blurStrength: null,
+    chromaStrength: null,
+    bloomStrength: null,
+    lensIntensity: null,
+    temporalBlend: null,
+    temporalFeedback: null,
   };
 
   const updateMetrics = (tick: TickInfo) => {
@@ -213,6 +324,198 @@ export const createDashboardModule = (): ModuleInstance => {
       state.renderSelect = renderSelect.select;
 
       container.appendChild(controlsSection);
+
+      const focusSection = document.createElement("div");
+      focusSection.style.display = "grid";
+      focusSection.style.rowGap = "6px";
+      focusSection.appendChild(createSectionTitle("Focus & Blur"));
+
+      const focusX = createSlider("Focus X", {
+        min: 0,
+        max: 1,
+        step: 0.01,
+        initial: config.postfx.focusCenter[0],
+        format: (value) => value.toFixed(2),
+      });
+      focusX.input.addEventListener("input", () => {
+        const value = parseFloat(focusX.input.value);
+        focusX.setValue(value);
+        const current = context.config.value.postfx.focusCenter;
+        context.config.patch({ postfx: { focusCenter: [value, current[1]] } });
+      });
+      focusSection.appendChild(focusX.wrapper);
+      state.focusX = focusX;
+
+      const focusY = createSlider("Focus Y", {
+        min: 0,
+        max: 1,
+        step: 0.01,
+        initial: config.postfx.focusCenter[1],
+        format: (value) => value.toFixed(2),
+      });
+      focusY.input.addEventListener("input", () => {
+        const value = parseFloat(focusY.input.value);
+        focusY.setValue(value);
+        const current = context.config.value.postfx.focusCenter;
+        context.config.patch({ postfx: { focusCenter: [current[0], value] } });
+      });
+      focusSection.appendChild(focusY.wrapper);
+      state.focusY = focusY;
+
+      const focusRadius = createSlider("Focus Radius", {
+        min: 0.05,
+        max: 0.6,
+        step: 0.01,
+        initial: config.postfx.focusInnerRadius,
+        format: (value) => value.toFixed(2),
+      });
+      focusRadius.input.addEventListener("input", () => {
+        const value = parseFloat(focusRadius.input.value);
+        focusRadius.setValue(value);
+        context.config.patch({ postfx: { focusInnerRadius: value } });
+      });
+      focusSection.appendChild(focusRadius.wrapper);
+      state.focusRadius = focusRadius;
+
+      const focusFeather = createSlider("Edge Feather", {
+        min: 0.2,
+        max: 0.95,
+        step: 0.01,
+        initial: config.postfx.focusOuterRadius,
+        format: (value) => value.toFixed(2),
+      });
+      focusFeather.input.addEventListener("input", () => {
+        const value = parseFloat(focusFeather.input.value);
+        focusFeather.setValue(value);
+        context.config.patch({ postfx: { focusOuterRadius: value } });
+      });
+      focusSection.appendChild(focusFeather.wrapper);
+      state.focusFeather = focusFeather;
+
+      const blurStrength = createSlider("Blur Strength", {
+        min: 0,
+        max: 0.12,
+        step: 0.001,
+        initial: config.postfx.blurStrength,
+        format: (value) => value.toFixed(3),
+      });
+      blurStrength.input.addEventListener("input", () => {
+        const value = parseFloat(blurStrength.input.value);
+        blurStrength.setValue(value);
+        context.config.patch({ postfx: { blurStrength: value } });
+      });
+      focusSection.appendChild(blurStrength.wrapper);
+      state.blurStrength = blurStrength;
+
+      container.appendChild(focusSection);
+
+      const opticsSection = document.createElement("div");
+      opticsSection.style.display = "grid";
+      opticsSection.style.rowGap = "6px";
+      opticsSection.appendChild(createSectionTitle("Optics"));
+
+      const chromaStrength = createSlider("Chromatic Strength", {
+        min: 0,
+        max: 2,
+        step: 0.01,
+        initial: config.postfx.chromaticAberrationStrength,
+        format: (value) => value.toFixed(2),
+      });
+      chromaStrength.input.addEventListener("input", () => {
+        const value = parseFloat(chromaStrength.input.value);
+        chromaStrength.setValue(value);
+        context.config.patch({ postfx: { chromaticAberrationStrength: value } });
+      });
+      opticsSection.appendChild(chromaStrength.wrapper);
+      state.chromaStrength = chromaStrength;
+
+      const bloomStrength = createSlider("Bloom Strength", {
+        min: 0,
+        max: 2,
+        step: 0.01,
+        initial: config.postfx.bloomStrength,
+        format: (value) => value.toFixed(2),
+      });
+      bloomStrength.input.addEventListener("input", () => {
+        const value = parseFloat(bloomStrength.input.value);
+        bloomStrength.setValue(value);
+        context.config.patch({ postfx: { bloomStrength: value } });
+      });
+      opticsSection.appendChild(bloomStrength.wrapper);
+      state.bloomStrength = bloomStrength;
+
+      const lensToggle = createToggle("Lens Streaks");
+      lensToggle.input.checked = config.postfx.lensStreaks;
+      lensToggle.input.addEventListener("change", () => {
+        context.config.patch({ postfx: { lensStreaks: lensToggle.input.checked } });
+      });
+      opticsSection.appendChild(lensToggle.wrapper);
+      state.lensToggle = lensToggle.input;
+
+      const lensIntensity = createSlider("Streak Intensity", {
+        min: 0,
+        max: 1,
+        step: 0.01,
+        initial: config.postfx.lensStreakIntensity,
+        format: (value) => value.toFixed(2),
+      });
+      lensIntensity.input.addEventListener("input", () => {
+        const value = parseFloat(lensIntensity.input.value);
+        lensIntensity.setValue(value);
+        context.config.patch({ postfx: { lensStreakIntensity: value } });
+      });
+      opticsSection.appendChild(lensIntensity.wrapper);
+      state.lensIntensity = lensIntensity;
+      lensIntensity.input.disabled = !config.postfx.lensStreaks;
+
+      container.appendChild(opticsSection);
+
+      const temporalSection = document.createElement("div");
+      temporalSection.style.display = "grid";
+      temporalSection.style.rowGap = "6px";
+      temporalSection.appendChild(createSectionTitle("Temporal"));
+
+      const temporalToggle = createToggle("Temporal Smoothing");
+      temporalToggle.input.checked = config.postfx.temporalEnabled;
+      temporalToggle.input.addEventListener("change", () => {
+        context.config.patch({ postfx: { temporalEnabled: temporalToggle.input.checked } });
+      });
+      temporalSection.appendChild(temporalToggle.wrapper);
+      state.temporalToggle = temporalToggle.input;
+
+      const temporalBlend = createSlider("Blend Weight", {
+        min: 0,
+        max: 1,
+        step: 0.01,
+        initial: config.postfx.temporalBlend,
+        format: (value) => value.toFixed(2),
+      });
+      temporalBlend.input.addEventListener("input", () => {
+        const value = parseFloat(temporalBlend.input.value);
+        temporalBlend.setValue(value);
+        context.config.patch({ postfx: { temporalBlend: value } });
+      });
+      temporalBlend.input.disabled = !config.postfx.temporalEnabled;
+      temporalSection.appendChild(temporalBlend.wrapper);
+      state.temporalBlend = temporalBlend;
+
+      const temporalFeedback = createSlider("Feedback", {
+        min: 0,
+        max: 0.98,
+        step: 0.01,
+        initial: config.postfx.temporalFeedback,
+        format: (value) => value.toFixed(2),
+      });
+      temporalFeedback.input.addEventListener("input", () => {
+        const value = parseFloat(temporalFeedback.input.value);
+        temporalFeedback.setValue(value);
+        context.config.patch({ postfx: { temporalFeedback: value } });
+      });
+      temporalFeedback.input.disabled = !config.postfx.temporalEnabled;
+      temporalSection.appendChild(temporalFeedback.wrapper);
+      state.temporalFeedback = temporalFeedback;
+
+      container.appendChild(temporalSection);
 
       const metricsSection = document.createElement("div");
       metricsSection.style.display = "grid";

--- a/src/postfx/postfx.ts
+++ b/src/postfx/postfx.ts
@@ -1,20 +1,59 @@
 // @ts-nocheck
 import * as THREE from "three/webgpu";
 import { bloom } from "three/examples/jsm/tsl/display/BloomNode.js";
-import { float, Fn, mrt, output, pass, vec3, vec4 } from "three/tsl";
+import { hashBlur } from "three/examples/jsm/tsl/display/hashBlur.js";
+import { chromaticAberration } from "three/examples/jsm/tsl/display/ChromaticAberrationNode.js";
+import { anamorphic } from "three/examples/jsm/tsl/display/AnamorphicNode.js";
+import { afterImage } from "three/examples/jsm/tsl/display/AfterImageNode.js";
+import {
+  clamp,
+  float,
+  Fn,
+  mix,
+  mrt,
+  output,
+  pass,
+  smoothstep,
+  uniform,
+  uv,
+  vec3,
+  vec4,
+} from "three/tsl";
 import type { ModuleInstance, TickInfo, AppContext, PostFxService } from "../context";
-import type { AppConfig } from "../config";
+import type { AppConfig, PostFxConfig } from "../config";
+
+interface PipelineNodes {
+  blurAmount: ReturnType<typeof uniform>;
+  blurIterations: ReturnType<typeof uniform>;
+  focusCenter: ReturnType<typeof uniform>;
+  focusInnerRadius: ReturnType<typeof uniform>;
+  focusOuterRadius: ReturnType<typeof uniform>;
+  chromaStrength: ReturnType<typeof uniform>;
+  chromaScale: ReturnType<typeof uniform>;
+  bloomEnabled: ReturnType<typeof uniform>;
+  lensThreshold: ReturnType<typeof uniform>;
+  lensStretch: ReturnType<typeof uniform>;
+  lensIntensity: ReturnType<typeof uniform>;
+  lensEnabled: ReturnType<typeof uniform>;
+  temporalBlend: ReturnType<typeof uniform>;
+}
 
 interface PostfxState {
   scenePass: ReturnType<typeof pass> | null;
   bloomPass: ReturnType<typeof bloom> | null;
+  lensPass: ReturnType<typeof anamorphic> | null;
+  temporalNode: ReturnType<typeof afterImage> | null;
   pipeline: THREE.PostProcessing | null;
   stageHandle: { renderer: THREE.WebGPURenderer; scene: THREE.Scene; camera: THREE.Camera } | null;
   unsubscribeConfig: (() => void) | null;
   currentConfig: AppConfig["postfx"] | null;
+  nodes: PipelineNodes | null;
 }
 
-const createPipeline = (renderer: THREE.WebGPURenderer, stage: { scene: THREE.Scene; camera: THREE.Camera }) => {
+const createPipeline = (
+  renderer: THREE.WebGPURenderer,
+  stage: { scene: THREE.Scene; camera: THREE.Camera }
+) => {
   const scenePass = pass(stage.scene, stage.camera);
   scenePass.setMRT(
     mrt({
@@ -25,20 +64,90 @@ const createPipeline = (renderer: THREE.WebGPURenderer, stage: { scene: THREE.Sc
 
   const outputPass = scenePass.getTextureNode();
   const bloomIntensityPass = scenePass.getTextureNode("bloomIntensity");
-  const bloomPass = bloom(outputPass.mul(bloomIntensityPass));
+  const blurAmount = uniform(0.04);
+  const blurIterations = uniform(32);
+  const focusCenter = uniform(new THREE.Vector2(0.5, 0.5));
+  const focusInnerRadius = uniform(0.2);
+  const focusOuterRadius = uniform(0.62);
+  const chromaStrength = uniform(0.8);
+  const chromaScale = uniform(1.1);
+  const bloomEnabled = uniform(1);
+  const lensThreshold = uniform(0.88);
+  const lensStretch = uniform(2.4);
+  const lensIntensity = uniform(0.25);
+  const lensEnabled = uniform(1);
+  const temporalBlend = uniform(0.5);
+
+  const blurredScene = hashBlur(outputPass, blurAmount, { repeats: blurIterations });
+  const uvNode = outputPass.uvNode || uv();
+  const radialMask = smoothstep(
+    focusInnerRadius,
+    focusOuterRadius,
+    uvNode.sub(focusCenter).length()
+  );
+  const focusComposite = mix(outputPass, blurredScene, radialMask);
+
+  const chroma = chromaticAberration(
+    focusComposite,
+    radialMask.mul(chromaStrength),
+    focusCenter,
+    chromaScale
+  );
+  const bloomSource = focusComposite.mul(bloomIntensityPass);
+  const bloomPass = bloom(bloomSource);
+  const lensPass = anamorphic(focusComposite, lensThreshold, lensStretch, 48);
+  lensPass.colorNode = vec3(0.85, 0.9, 1.0);
+
+  const composite = Fn(() => {
+    const focused = chroma.toVar();
+    const bloomColor = bloomPass.rgb.mul(bloomEnabled).toVar();
+    const lensColor = lensPass
+      .getTextureNode()
+      .rgb.mul(lensIntensity)
+      .mul(lensEnabled)
+      .toVar();
+    const combined = focused.rgb.add(bloomColor).add(lensColor).clamp(0, 1);
+    return vec4(combined, focused.a);
+  });
+
+  const compositeNode = composite();
+  const temporalResolved = afterImage(compositeNode, 0.85);
+
+  const outputNode = Fn(() => {
+    const current = compositeNode.toVar();
+    const temporal = temporalResolved.toVar();
+    const mixed = mix(current, temporal, temporalBlend);
+    const color = clamp(mixed.rgb, 0, 1);
+    return vec4(color, current.a);
+  })().renderOutput();
 
   const pipeline = new THREE.PostProcessing(renderer);
   pipeline.outputColorTransform = false;
-  pipeline.outputNode = Fn(() => {
-    const a = outputPass.rgb.clamp(0, 1).toVar();
-    const b = bloomPass.rgb.clamp(0, 1).mul(bloomIntensityPass.r.sign().oneMinus()).toVar();
-    return vec4(vec3(1).sub(b).sub(b).mul(a).mul(a).add(b.mul(a).mul(2)).clamp(0, 1), 1);
-  })().renderOutput();
+  pipeline.outputNode = outputNode;
+
+  const nodes: PipelineNodes = {
+    blurAmount,
+    blurIterations,
+    focusCenter,
+    focusInnerRadius,
+    focusOuterRadius,
+    chromaStrength,
+    chromaScale,
+    bloomEnabled,
+    lensThreshold,
+    lensStretch,
+    lensIntensity,
+    lensEnabled,
+    temporalBlend,
+  };
 
   return {
     scenePass,
     bloomPass,
+    lensPass,
+    temporalNode: temporalResolved,
     pipeline,
+    nodes,
   } as const;
 };
 
@@ -46,18 +155,47 @@ const disposePipeline = (state: PostfxState) => {
   state.pipeline?.dispose();
   state.pipeline = null;
   state.scenePass = null;
+  state.bloomPass?.dispose?.();
   state.bloomPass = null;
+  state.lensPass?.dispose?.();
+  state.lensPass = null;
+  state.temporalNode?.dispose?.();
+  state.temporalNode = null;
   state.stageHandle = null;
+  state.nodes = null;
 };
 
-const applyConfig = (state: PostfxState, config: AppConfig["postfx"]) => {
+const applyConfig = (state: PostfxState, config: PostFxConfig) => {
   state.currentConfig = config;
-  if (!state.bloomPass) {
+  const nodes = state.nodes;
+  if (!nodes || !state.bloomPass || !state.lensPass || !state.temporalNode) {
     return;
   }
+
+  nodes.blurAmount.value = Math.max(0, config.blurStrength);
+  nodes.blurIterations.value = Math.max(1, config.blurIterations);
+  const centerX = Math.min(Math.max(config.focusCenter[0], 0), 1);
+  const centerY = Math.min(Math.max(config.focusCenter[1], 0), 1);
+  nodes.focusCenter.value.set(centerX, centerY);
+  const innerRadius = Math.max(0, Math.min(config.focusInnerRadius, config.focusOuterRadius - 0.001));
+  const outerRadius = Math.max(innerRadius + 0.001, config.focusOuterRadius);
+  nodes.focusInnerRadius.value = innerRadius;
+  nodes.focusOuterRadius.value = outerRadius;
+  nodes.chromaStrength.value = Math.max(0, config.chromaticAberrationStrength);
+  nodes.chromaScale.value = Math.max(0.5, config.chromaticAberrationScale);
+  nodes.bloomEnabled.value = config.bloom ? 1 : 0;
+  nodes.lensThreshold.value = config.lensStreakThreshold;
+  nodes.lensStretch.value = config.lensStreakStretch;
+  nodes.lensIntensity.value = Math.max(0, config.lensStreakIntensity);
+  nodes.lensEnabled.value = config.lensStreaks ? 1 : 0;
+  nodes.temporalBlend.value = config.temporalEnabled ? Math.min(Math.max(config.temporalBlend, 0), 1) : 0;
+
   state.bloomPass.threshold.value = config.bloomThreshold;
   state.bloomPass.strength.value = config.bloomStrength;
   state.bloomPass.radius.value = config.bloomRadius;
+
+  state.lensPass.resolutionScale = 0.5;
+  state.temporalNode.damp.value = Math.min(Math.max(config.temporalFeedback, 0), 0.98);
 };
 
 const ensurePipeline = (state: PostfxState, context: AppContext) => {
@@ -74,13 +212,18 @@ const ensurePipeline = (state: PostfxState, context: AppContext) => {
   const resources = createPipeline(context.renderer, stage);
   state.scenePass = resources.scenePass;
   state.bloomPass = resources.bloomPass;
+  state.lensPass = resources.lensPass;
+  state.temporalNode = resources.temporalNode;
   state.pipeline = resources.pipeline;
   state.stageHandle = stage;
+  state.nodes = resources.nodes;
   applyConfig(state, state.currentConfig ?? context.config.value.postfx);
   context.services.postfx = {
     pipeline: state.pipeline,
     bloomPass: state.bloomPass,
     scenePass: state.scenePass,
+    lensPass: state.lensPass,
+    temporalNode: state.temporalNode,
   } as PostFxService;
   return true;
 };
@@ -90,10 +233,13 @@ export const createPostfxModule = (): ModuleInstance => {
   const state: PostfxState = {
     scenePass: null,
     bloomPass: null,
+    lensPass: null,
+    temporalNode: null,
     pipeline: null,
     stageHandle: null,
     unsubscribeConfig: null,
     currentConfig: null,
+    nodes: null,
   };
 
   return {
@@ -118,9 +264,8 @@ export const createPostfxModule = (): ModuleInstance => {
       if (!stage) {
         return;
       }
-      const postfxConfig = tick.config.postfx;
       tick.setRenderOverride(async () => {
-        if (postfxConfig.bloom && state.pipeline) {
+        if (state.pipeline) {
           await state.pipeline.renderAsync();
         } else {
           await tick.context.renderer.renderAsync(stage.scene, stage.camera);


### PR DESCRIPTION
## Summary
- replace the simple bloom-only post-processing with a multi-stage stack combining hash blur, radial focus masking, chromatic aberration, bloom, anamorphic streaks, and temporal smoothing
- add configuration fields and dashboard controls for focus center, blur amount, chromatic aberration intensity, bloom strength, lens streak toggles, and temporal blending/feedback
- expose additional post-fx service handles so downstream systems can access the lens and temporal passes

## Testing
- npm run typecheck *(fails: Cannot find type definition file for 'vitest/globals')*

------
https://chatgpt.com/codex/tasks/task_e_68d968314fa48327a98eced09837ba40